### PR TITLE
Updated tsconfig to es5 instead of es2015 for IE compatibility

### DIFF
--- a/tsconfig.production.json
+++ b/tsconfig.production.json
@@ -1,6 +1,8 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "sourceMap": false
+    "sourceMap": false,
+    "target": "es5",
+    "lib": ["dom", "es2015"]
   }
 }


### PR DESCRIPTION
Hello, Thank you for this nice project.
I updated tsconfig to es5 instead of es2015 for IE compatibility for production builds.
Because, I want to use `use-http(with polyfill)` with IE11, but IE not support Arrow Functions...