### PR TITLE
Fix TS2322 error with TypeScript 3.8.3

### DIFF
--- a/useRefState.ts
+++ b/useRefState.ts
@@ -20,7 +20,7 @@ const useMounted = () => {
 export function useRefState<S>(
   initialState: S | (() => S),
   blockIfUnmounted: boolean = true
-): [MutableRefObject<S>, Dispatch<SetStateAction<S>>] {
+): [MutableRefObject<S | (() => S)>, Dispatch<SetStateAction<S>>] {
   const mounted = useMounted()
   const [reactState, setReactState] = useState(initialState)
   const state = useRef(initialState)


### PR DESCRIPTION

I got bellow errors: 
```powershell
$ npx tsc -v
Version 3.8.3
$ rimraf dist && tsc --module CommonJS
useRefState.ts:32:11 - error TS2322: Type 'MutableRefObject<S | (() => S)>' is not assignable to type 'MutableRefObject<S>'.
  Type 'S | (() => S)' is not assignable to type 'S'.
    'S | (() => S)' is assignable to the constraint of type 'S', but 'S' could be instantiated with a different subtype of constraint '{}'.
      Type '() => S' is not assignable to type 'S'.
        '() => S' is assignable to the constraint of type 'S', but 'S' could be instantiated with a different subtype of constraint '{}'.

32   return [state, setState]
             ~~~~~
```
This PR works for me.
